### PR TITLE
Extended readme and added support for FIRMATA_DEVICE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,44 @@ This is a balena application that allows to flash the balenaFin Coprocessor with
 
 ### Getting started
 
-1. Setup your balena account and push to your application following the [getting started](https://www.balena.io/docs/learn/getting-started/fincm3/python/#account-setup) guide.
-2. Check the balenaCloud terminal for your application to see if your device has successfully connected and flashed the bootloader & firmata application for the Coprocessor.
+1. Setup your balena account and push to your application following the [getting started](https://www.balena.io/docs/learn/getting-started/fincm3/python/#account-setup) guide, but don't flash the image you've downloaded to your balenaFin yet.
+2. Set the following variable in the *fleet configuration* menu (leave the quotes as-is):
+   - `RESIN_HOST_CONFIG_dtoverlay` = `"balena-fin","uart0,txd0_pin=32,rxd0_pin=33,pin_func=7"`
+3. Set the following variable in the *environment variables* menu:
+   - `FIRMATA_DEVICE` = `/dev/ttyAMA0`
+4. Flash the image to your Fin
+5. **(Only when using the development image)** If you're using the development version of balenaOS, you'll need to disable the serial console. Edit `cmdline.txt` on the `resin_boot` partition to remove this part of the line: `console=ttyAMA0,115200`. 
+6. Remove your Fin from the USB connector and power it on.
+7. Check the balenaCloud terminal for your application to see if your device has successfully connected and flashed the bootloader & firmata application for the Coprocessor.
+8. **(Only when using the development image)** Stop getty from trying to start up a serial console. SSH in to the host OS of your balenaFin (you can do this through balenaCloud or the CLI). Run the following commands:
+    ```
+    mount -o remount,rw /
+    systemctl mask serial-getty@serial0.service
+    reboot
+    ```
+9.  You can now test the connection to the coprocessor as described below.
+
+### Optional: Use miniUART
+
+If you require using uart0 for some other purpose than the coprocessor, you can use the miniUART on the CM3 to connect to the coprocessor. As the miniUART is tied to the main CPU, this requires setting the Pi's ARM core to a fixed speed, so it will probably use more power. To do this, you can omit steps 5 and 8 from the list above, and use the following variables in steps 2 and 3:
+
+In the *fleet configuration* menu (leave the quotes as-is):
+   - `RESIN_HOST_CONFIG_dtoverlay` = `"balena-fin","uart1,txd1_pin=32,rxd1_pin=33"`
+   - `RESIN_HOST_CONFIG_core_freq` = `250`
+
+In the *environment variables* menu:
+   - `FIRMATA_DEVICE` = `/dev/ttyS0`
+
+This frees up `/dev/ttyAMA0` to use for another purpose.
 
 ### Checking Firmata is working correctly
+
+To check if the Firmata is working correctly, run the following command inside your container:
+```bash
+node main.js
+```
+If it doesn't work, you may need to restart your device with the `STOP` environment variable set, because switching the coprocessor mux while running may cause some issues. Use the *environment variables* menu in balenaCloud to set it to anything other than an empty string. This will stop the container from flashing the coprocessor each time it starts.
+
 
 The Firmata protocol should correctly output the messages `X ✔ firmware name` and `Y.Z ✔ firmata version` (where `Y` & `Z` are the current supported `MAJOR` & `MINOR` versions of firmata) when the balena application has been successfully started.
 

--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,6 @@
 const readline = require('readline');
 const Firmata = require("firmata");
-const board = new Firmata("/dev/ttyS0");
+const board = new Firmata(process.env.FIRMATA_DEVICE || "/dev/ttyS0");
 
 readline.emitKeypressEvents(process.stdin);
 process.stdin.setRawMode(true);


### PR DESCRIPTION
In trying to get this repo to work with my Fin I found that the existing documentation did not cover everything that I needed to get it to work. I added everything I found out so others will have an easier experience. 
I also found out how to use the "full" uart (UART0) to communicate with the coprocessor, which is exposed through `/dev/ttyAMA0`. I prefer this to the miniUART because it doesn't require the cpu to be set to a fixed speed. I added a minor change to `main.js` to accomodate an env var which points to the port.