### PR TITLE
Allow automatic flashing

### DIFF
--- a/co-processor/app/flasher.js
+++ b/co-processor/app/flasher.js
@@ -1,0 +1,88 @@
+const Gpio = require('onoff').Gpio;
+const mux = new Gpio(41, 'out');
+const { spawn } = require("child_process");
+
+let flashingInProgress = false;
+
+function newFlasher(finRevision, supervisor, firmata) {
+  return {
+    flash: function (name) {
+      return new Promise((resolve, reject) => {
+        if (flashingInProgress) {
+          reject(new Error('Flashing is already in progress'));
+          return;
+        }
+
+        let errorCheck = 0;
+
+        flashingInProgress = true;
+        mux.writeSync(1);
+        const flash = spawn("/usr/src/app/flash.sh", [name, finRevision]);
+
+        flash.stdout.on('data', (data) => {
+          console.log("flash stdout: " + data);
+        });
+
+        flash.stderr.on('data', (data) => {
+          console.error("flash stderr: " + data);
+
+          if (!data.includes('Connection closed by foreign host.')) {
+            errorCheck++;
+            reject(new Error(`Flashing failed with message: ${data}`));
+          }
+        });
+
+        flash.on('error', (err) => {
+          console.error(err);
+          errorCheck++;
+          reject(err);
+        });
+
+        flash.on('close', () => {
+          mux.writeSync(0);
+
+          if (errorCheck === 0) {
+            resolve();
+          } else {
+            console.log('flash failed! device will not reboot.');
+            errorCheck = 0;
+          }
+        });
+      })
+          .finally(() => {
+            flashingInProgress = false;
+          })
+          .then(() => {
+            if (finRevision > '09') {
+              console.log('rebooting via supervisor...');
+              // We trigger the reboot, but don't await it.
+              supervisor.reboot()
+                  .catch((err) => {
+                    console.error('reboot failed with error: ', err);
+                  });
+            }
+          });
+    },
+
+    flashIfNeeded: function (filePath, meta) {
+      return firmata.queryFirmware()
+          .catch(() => {
+            // We cannot query firmware.
+            return { firmataName: '', firmataVersion: '' };
+          })
+          .then(({ firmataName: currentName, firmataVersion: currentVersion }) => {
+            if (currentName !== meta.name || currentVersion !== meta.version) {
+              console.log('Start automatic flashing...');
+              return this.flash(filePath).then(() => true);
+            }
+            return false;
+          });
+    },
+
+    stop: function () {
+      mux.unexport();
+    }
+  };
+}
+
+module.exports = newFlasher;


### PR DESCRIPTION
If FLASH_ON_START variables are defined, the service will attempt to flash the specified
firmware on start but only if this firmware is not yet reported to be present on the co-processor.

Also, refactored the code in the index.js, extracting the flashing logic into a separatee module
and cleaning up sleep command promises.

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>